### PR TITLE
Allow to use custom log file names

### DIFF
--- a/lib/irb_tracker/irb_loggable.rb
+++ b/lib/irb_tracker/irb_loggable.rb
@@ -5,8 +5,8 @@ require 'irb_tracker/logger_factory'
 module IRBTracker
   #:nodoc:
   class IRBLoggable < Module
-    def initialize(service_name = 'undefined')
-      logger = LoggerFactory.create service_name
+    def initialize(service_name = 'undefined', file_name = 'console.log')
+      logger = LoggerFactory.create service_name, file_name
       # rubocop:disable Style/RedundantBegin
       define_method :evaluate do |*args, &block|
         begin

--- a/lib/irb_tracker/logger_factory.rb
+++ b/lib/irb_tracker/logger_factory.rb
@@ -2,7 +2,7 @@
 
 #:nodoc:
 module LoggerFactory
-  def self.create(service_name)
+  def self.create(service_name, file_name)
     if ENV['FLUENTD_LOGGING_ENABLED'] == 'true'
       require_relative '../fluentd'
       Fluentd.get_logger(
@@ -14,7 +14,7 @@ module LoggerFactory
       require 'logger'
       log_folder = 'log'
       Dir.mkdir(log_folder) unless Dir.exist?(log_folder)
-      Logger.new("./#{log_folder}/console.log")
+      Logger.new("./#{log_folder}/#{file_name}")
     end
   end
 end


### PR DESCRIPTION
This PR allows a custom log file name to be supplied to the constructor.

Current behavior: The log file has a hard-coded name (`console.log`).

New behavior: The log file can have its name customized, keeping the old hard-coded name as the default name.